### PR TITLE
Add check to ensure that haystack is large enough to contain the needle.

### DIFF
--- a/base/mem/m_mem.c
+++ b/base/mem/m_mem.c
@@ -371,7 +371,7 @@ void *M_mem_mem(const void *haystack, size_t haystack_len, const void *needle, s
 	const M_uint8 *pos;
 	const M_uint8 *ret = NULL;
 
-	if (haystack == NULL || haystack_len == 0) {
+	if (haystack == NULL || haystack_len == 0 || needle_len > haystack_len) {
 		return NULL;
 	}
 	if (needle == NULL || needle_len == 0) {


### PR DESCRIPTION
If haystack_len is less than needle_len, it causes an integer underflow in m_mem.c:381.

The call at m_mem.c:397 to M_mem_eq will result in an out of bounds read.

Reproduction:
Compile with ASAN enabled. Pass the following bytes to M_xml_read.
"\x7f\x0a\x65\x65\x65\x67\x74\x79\x70\x3c\x21\x20\x2d\x2d\x0a\x2d"