### PR TITLE
ble mac: query the OS for peripherals before scanning for them

### DIFF
--- a/include/mstdlib/io/m_io_ble.h
+++ b/include/mstdlib/io/m_io_ble.h
@@ -103,7 +103,7 @@ __BEGIN_DECLS
  * Characteristics with the notify or indicate property can be subscribed to which will
  * have them issue read events similar to a stream protocol. Reads will still require a meta
  * object to specify which service and characteristic the data is from. Manual read requests
- * may still be necessary. Notify and Indicate events are left to the device to imitate.
+ * may still be necessary. Notify and Indicate events are left to the device to initiate.
  * The device may have internal rules which limit how often events are triggered. For example
  * a heart rate monitor could notify every 2 seconds even though it's reading every 100 ms. A
  * time service might send an event every second or it might send an event every minute.

--- a/io/m_io_ble_mac.m
+++ b/io/m_io_ble_mac.m
@@ -264,7 +264,7 @@ M_io_error_t M_io_ble_read_cb(M_io_layer_t *layer, unsigned char *buf, size_t *r
 	M_llist_node_t   *node;
 	M_io_ble_rdata_t *rdata;
 
-	/* Validae we have a meta object. If not we don't know what to do. */
+	/* Validate we have a meta object. If not we don't know what to do. */
 	if (meta == NULL)
 		return M_IO_ERROR_INVALID;
 
@@ -292,20 +292,18 @@ M_io_error_t M_io_ble_read_cb(M_io_layer_t *layer, unsigned char *buf, size_t *r
 	M_hash_multi_u64_insert_int(mdata, M_IO_BLE_META_KEY_READ_TYPE, rdata->type);
 	switch (rdata->type) {
 		case M_IO_BLE_RTYPE_READ:
-			if (buf == NULL || read_len == NULL) {
-				return M_IO_ERROR_INVALID;
-			}
-
 			/* Set the service and characteristic uuids for where the data came from. */
 			M_hash_multi_u64_insert_str(mdata, M_IO_BLE_META_KEY_SERVICE_UUID, rdata->d.read.service_uuid);
 			M_hash_multi_u64_insert_str(mdata, M_IO_BLE_META_KEY_CHARACTERISTIC_UUID, rdata->d.read.characteristic_uuid);
 
 			/* Read as much data as we can. */
-			if (*read_len > M_buf_len(rdata->d.read.data))
-				*read_len = M_buf_len(rdata->d.read.data);
+			if (buf != NULL && read_len != NULL) {
+				if (*read_len > M_buf_len(rdata->d.read.data))
+					*read_len = M_buf_len(rdata->d.read.data);
 
-			M_mem_copy(buf, M_buf_peek(rdata->d.read.data), *read_len);
-			M_buf_drop(rdata->d.read.data, *read_len);
+				M_mem_copy(buf, M_buf_peek(rdata->d.read.data), *read_len);
+				M_buf_drop(rdata->d.read.data, *read_len);
+			}
 
 			/* If we've read everything we will drop this record. */
 			if (M_buf_len(rdata->d.read.data) == 0) {


### PR DESCRIPTION
Speeds up connections when the OS already have the device cached.