### PR TITLE
add M_str_isbase64() and M_str_isbase64_max()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,3 @@ Thumbs.db
 ######################
 run.sh
 temp.c
-temp

--- a/.gitignore
+++ b/.gitignore
@@ -161,8 +161,3 @@ Makefile.in
 .Trashes
 ehthumbs.db
 Thumbs.db
-
-# Local to this machine #
-######################
-local.sh
-local.c

--- a/.gitignore
+++ b/.gitignore
@@ -164,5 +164,5 @@ Thumbs.db
 
 # Local to this machine #
 ######################
-run.sh
-temp.c
+local.sh
+local.c

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -106,10 +106,10 @@ static M_bool M_str_eq_max_int(const char *s1, const char *s2, volatile size_t m
 	 * For example, dummy vars that are set but never used.
 	 */
 	char                 result = 0;
-	volatile size_t      i      = 0;
+	size_t               i      = 0;
 	volatile size_t      j      = 0;
 	volatile size_t      k      = 0;
-	volatile M_bool      ret;
+	M_bool               ret;
 	volatile const char *sc     = NULL;
 
 	/* Set the input to an empty string if it's NULL.

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -707,20 +707,21 @@ M_bool M_str_isbase64_max(const char *s, size_t max)
 		return M_FALSE;
 
 	len = M_str_len(s);
-	if (len > max)
-		len = max;
+	if (max > len)
+		max = len;
 
-	/* Only check for one before the end so we can allow '=' as padding */
-	for (i=0; i<len-1; i++) {
+	for (i=0; i<max; i++) {
+		/* Allow for the string to be padded with '='. */
+		if (s[i] == '=') {
+			if (i == len-2 && s[len-1] == '=') {
+				continue;
+			} else if (i == len-1) {
+				continue;
+			}
+		}
+
 		if (!M_chr_isalnum(s[i]) && s[i] != '+' && s[i] != '/')
 			return M_FALSE;
-	}
-
-	if (
-		(!M_chr_isalnum(s[i]) && s[i] != '+' && s[i] != '/' && s[i] != '=') ||
-		(s[i] == '=' && M_str_len(s) > max) /* '=' is only allowed at very end of string for padding */
-	) {
-		return M_FALSE;
 	}
 
 	return M_TRUE;

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -527,6 +527,11 @@ M_bool M_str_ishex(const char *s)
 	return M_str_ispredicate_max_inline(s, SIZE_MAX, M_chr_ishex);
 }
 
+M_bool M_str_isbase64(const char *s)
+{
+	return M_str_isbase64_max(s, SIZE_MAX);
+}
+
 M_bool M_str_isnum(const char *s)
 {
 	return M_str_ispredicate_max_inline(s, SIZE_MAX, M_chr_isdigit);
@@ -691,6 +696,34 @@ M_bool M_str_isprint_max(const char *s, size_t max)
 M_bool M_str_ishex_max(const char *s, size_t max)
 {
 	return M_str_ispredicate_max_inline(s, max, M_chr_ishex);
+}
+
+M_bool M_str_isbase64_max(const char *s, size_t max)
+{
+	size_t       len;
+	unsigned int i;
+
+	if (s == NULL || *s == '\0')
+		return M_FALSE;
+
+	len = M_str_len(s);
+	if (len > max)
+		len = max;
+
+	/* Only check for one before the end so we can allow '=' as padding */
+	for (i=0; i<len-1; i++) {
+		if (!M_chr_isalnum(s[i]) && s[i] != '+' && s[i] != '/')
+			return M_FALSE;
+	}
+
+	if (
+		(!M_chr_isalnum(s[i]) && s[i] != '+' && s[i] != '/' && s[i] != '=') ||
+		(s[i] == '=' && M_str_len(s) > max) /* '=' is only allowed at very end of string for padding */
+	) {
+		return M_FALSE;
+	}
+
+	return M_TRUE;
 }
 
 M_bool M_str_isnum_max(const char *s, size_t max)

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -713,14 +713,16 @@ M_bool M_str_isbase64_max(const char *s, size_t max)
 	for (i=0; i<max; i++) {
 		/* Allow for the string to be padded with '='. */
 		if (s[i] == '=') {
-			if (i == len-2 && s[len-1] == '=') {
+			if (i == len-3 && s[len-2] == '\n' && s[len-1] == '=') {
+				continue;
+			} else if (i == len-2 && s[len-1] == '=') {
 				continue;
 			} else if (i == len-1) {
 				continue;
 			}
 		}
 
-		if (!M_chr_isalnum(s[i]) && s[i] != '+' && s[i] != '/')
+		if (!M_chr_isalnum(s[i]) && s[i] != '+' && s[i] != '/' && s[i] != '\n')
 			return M_FALSE;
 	}
 

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -252,6 +252,29 @@ static M_bool is_escaped(const char *str, const char *str_pos, char escape)
 	return (escape_count % 2 == 1)? M_TRUE : M_FALSE;
 }
 
+static M_bool is_base64_char(unsigned char c)
+{
+	/* Return M_TRUE if c is in this character set: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/ */
+
+	/* + and / */
+	if (c == 43 || c == 47)
+		return M_TRUE;
+
+	/* 0 - 9 */
+	if (c >= 48 && c <= 57)
+		return M_TRUE;
+
+	/* A - Z */
+	if (c >= 65 && c <= 90)
+		return M_TRUE;
+
+	/* a - z */
+	if (c >= 97 && c <= 122)
+		return M_TRUE;
+
+	return M_FALSE;
+}
+
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 const char *M_str_safe(const char *s)
@@ -701,37 +724,36 @@ M_bool M_str_ishex_max(const char *s, size_t max)
 
 M_bool M_str_isbase64_max(const char *s, size_t max)
 {
-	M_bool              ret = M_FALSE;
-	M_parser_t         *const_parser;
-	M_parser_t        **parsers;
-	size_t              count;
-	size_t              first_len;
-	size_t              tmp_len;
-	unsigned int        i;
-	static const char   base64_charset[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	M_bool         ret = M_FALSE;
+	M_parser_t    *const_parser;
+	M_parser_t   **lines;
+	size_t         line_cnt;
+	size_t         std_len;
+	size_t         tmp_len;
+	unsigned int   i;
 
 	if (M_str_isempty(s) || max < 4)
 		return M_FALSE;
 
 	const_parser = M_parser_create_const((unsigned char *)s, max, M_PARSER_FLAG_NONE);
-	parsers      = M_parser_split(const_parser, '\n', 0, M_PARSER_SPLIT_FLAG_NONE, &count);
+	lines        = M_parser_split(const_parser, '\n', 0, M_PARSER_SPLIT_FLAG_NONE, &line_cnt);
 
-	first_len = M_parser_len(parsers[0]);
-	for (i=0; i<count; i++) {
-		tmp_len = M_parser_len(parsers[i]);
+	std_len = M_parser_len(lines[0]);
+	for (i=0; i<line_cnt; i++) {
+		tmp_len = M_parser_len(lines[i]);
 		if (
-			(i <  count-1 && tmp_len != first_len) || /* All lines except for the last must be the same length. */
-			(i == count-1 && tmp_len >  first_len) || /* The last line must be equal to or shorter than the others. */
-			tmp_len % 4 != 0                          /* All data must be in blocks of 4. */
+			(i <  line_cnt-1 && tmp_len != std_len) || /* All lines except for the last must be the same length. */
+			(i == line_cnt-1 && tmp_len >  std_len) || /* The last line must be equal to or shorter than the others. */
+			tmp_len % 4 != 0                            /* All data must be in blocks of 4. */
 		) {
 			goto done;
 		}
 
-		if (M_parser_consume_str_charset(parsers[i], base64_charset) != tmp_len) {
-			if (i != count-1) {
+		if (M_parser_consume_predicate(lines[i], is_base64_char) != tmp_len) {
+			if (i != line_cnt-1) {
 				/* All lines except for the last can only have characters in the base64 character set. */
 				goto done;
-			} else if (M_parser_consume_str_charset(parsers[i], "=") > 2 || M_parser_len(parsers[i]) != 0) {
+			} else if (M_parser_consume_str_charset(lines[i], "=") > 2 || M_parser_len(lines[i]) != 0) {
 				/* Only the last and second-to-last characters can be padding.
 				 * If the second-to-last character is a '=', the last one must be as well. */
 				goto done;
@@ -742,7 +764,7 @@ M_bool M_str_isbase64_max(const char *s, size_t max)
 	/* If we made it this far, then we passed all validations. */
 	ret = M_TRUE;
 done:
-	M_parser_split_free(parsers, count);
+	M_parser_split_free(lines, line_cnt);
 	M_parser_destroy(const_parser);
 	return ret;
 }

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -703,7 +703,7 @@ M_bool M_str_isbase64_max(const char *s, size_t max)
 	size_t       len;
 	unsigned int i;
 
-	if (s == NULL || *s == '\0')
+	if (M_str_isempty(s))
 		return M_FALSE;
 
 	len = M_str_len(s);
@@ -713,12 +713,14 @@ M_bool M_str_isbase64_max(const char *s, size_t max)
 	for (i=0; i<max; i++) {
 		/* Allow for the string to be padded with '='. */
 		if (s[i] == '=') {
-			if (i == len-3 && s[len-2] == '\n' && s[len-1] == '=') {
-				continue;
-			} else if (i == len-2 && s[len-1] == '=') {
-				continue;
-			} else if (i == len-1) {
-				continue;
+			if (i == max-3) {
+				return M_str_eq_max(s+i, "=\n=", 3);
+			} else if (i == max-2) {
+				return M_str_eq_max(s+i, "==", 2);
+			} else if (i == max-1) {
+				return M_TRUE;
+			} else {
+				return M_FALSE;
 			}
 		}
 

--- a/base/data/m_str.c
+++ b/base/data/m_str.c
@@ -128,10 +128,10 @@ static M_bool M_str_eq_max_int(const char *s1, const char *s2, volatile size_t m
 	 * max past the end of s1 but if they do, we'll scan past the end
 	 * of s1 which isn't good. We can only do so much. */
 	i = max;
-	if (max == 0)
-		max = SIZE_MAX;
 	if (max != 0)
 		max = i;
+	if (max == 0)
+		max = SIZE_MAX;
 
 	/* Constant time comparison.  We scan the entire string to prevent timing attacks.
 	 * We don't want to do strlen()'s first that will leak info

--- a/include/mstdlib/base/m_str.h
+++ b/include/mstdlib/base/m_str.h
@@ -282,6 +282,20 @@ M_API M_bool M_str_isprint(const char *s) M_WARN_UNUSED_RESULT;
 M_API M_bool M_str_ishex(const char *s) M_WARN_UNUSED_RESULT;
 
 
+/*! Check whether each character of a string s is in the base64 character set.
+ *
+ * The base64 character set is all letters upper and lower case, the digits
+ * 0-9, and the special characters '+' and '/'.
+ *
+ * The final character may be '=' to allow for padding.
+ *
+ * \param[in] s NULL-terminated string.
+ *
+ * \return M_TRUE if all characters match. Otherwise M_FALSE.
+ */
+M_API M_bool M_str_isbase64(const char *s) M_WARN_UNUSED_RESULT;
+
+
 /*! Check whether each character of a string s is a decimal digit 0-9.
  *
  * \param[in] s NULL-terminated string.
@@ -434,6 +448,21 @@ M_API M_bool M_str_isprint_max(const char *s, size_t max) M_WARN_UNUSED_RESULT;
  * \return M_TRUE if all characters match. Otherwise M_FALSE.
  */
 M_API M_bool M_str_ishex_max(const char *s, size_t max) M_WARN_UNUSED_RESULT;
+
+
+/*! Check whether each character of a string s is in the base64 character set up to at most max bytes.
+ *
+ * The base64 character set is all letters upper and lower case, the digits
+ * 0-9, and the special characters '+' and '/'.
+ *
+ * The final character may be '=' to allow for padding.
+ *
+ * \param[in] s   NULL-terminated string.
+ * \param[in] max Maximum number of bytes.
+ *
+ * \return M_TRUE if all characters match. Otherwise M_FALSE.
+ */
+M_API M_bool M_str_isbase64_max(const char *s, size_t max) M_WARN_UNUSED_RESULT;
 
 
 /*! Check whether each character of a string s is a decimal digit 0-9 up to at most max bytes.

--- a/include/mstdlib/base/m_str.h
+++ b/include/mstdlib/base/m_str.h
@@ -285,9 +285,9 @@ M_API M_bool M_str_ishex(const char *s) M_WARN_UNUSED_RESULT;
 /*! Check whether each character of a string s is in the base64 character set.
  *
  * The base64 character set is all letters upper and lower case, the digits
- * 0-9, and the special characters '+' and '/'.
+ * 0-9, and the special characters '+' and '/'. Newlines ('\n') are also allowed.
  *
- * The final character may be '=' to allow for padding.
+ * Up to two '=' characters are allowed at the end of the string for padding.
  *
  * \param[in] s NULL-terminated string.
  *
@@ -453,9 +453,9 @@ M_API M_bool M_str_ishex_max(const char *s, size_t max) M_WARN_UNUSED_RESULT;
 /*! Check whether each character of a string s is in the base64 character set up to at most max bytes.
  *
  * The base64 character set is all letters upper and lower case, the digits
- * 0-9, and the special characters '+' and '/'.
+ * 0-9, and the special characters '+' and '/'. Newlines ('\n') are also allowed.
  *
- * The final character may be '=' to allow for padding.
+ * Up to two '=' characters are allowed at the end of the string for padding.
  *
  * \param[in] s   NULL-terminated string.
  * \param[in] max Maximum number of bytes.

--- a/include/mstdlib/base/m_str.h
+++ b/include/mstdlib/base/m_str.h
@@ -520,8 +520,16 @@ M_API int M_str_casecmpsort_max(const char *s1, const char *s2, size_t max) M_WA
  * This implementation is constant-time meaning it should not be vulnerable to timing-based attacks. 
  * Limited to first max bytes.  NULL and "" are considered equal strings.
  *
- * \param[in] s1  NULL-terminated string.
- * \param[in] s2  NULL-terminated string.
+ * s1 will be evaluated to max regardless of the length of s2.
+ * s1 should be the input (user) string and s2 the known (internal)
+ * string. This order causes any timing information from this function
+ * to be the timing of reading s1. The length of s2 cannot be determined
+ * using this order. If s1 is the known (internal) string it is possible,
+ * though highly unlikely, to determine the length. While the evaluation
+ * will be constant time it will always be the time to scan the known string.
+ *
+ * \param[in] s1  NULL-terminated string. Should be (user) input.
+ * \param[in] s2  NULL-terminated string. Should be known (internal) string.
  * \param[in] max maximum length to check, or 0 for no maximum.
  *
  * \return M_TRUE if equal, M_FALSE if not equal.
@@ -534,8 +542,16 @@ M_API M_bool M_str_eq_max(const char *s1, const char *s2, size_t max);
  * This implementation is constant-time meaning it should not be vulnerable to timing-based attacks.
  * NULL and "" are considered equal strings.
  *
- * \param[in] s1 NULL-terminated string.
- * \param[in] s2 NULL-terminated string.
+ * s1 will be evaluated to end regardless of the length of s2.
+ * s1 should be the input (user) string and s2 the known (internal)
+ * string. This order causes any timing information from this function
+ * to be the timing of reading s1. The length of s2 cannot be determined
+ * using this order. If s1 is the known (internal) string it is possible
+ * though highly unlikely, to determine the length. While the evaluation
+ * will be constant time it will always be the time to scan the known string.
+ *
+ * \param[in] s1  NULL-terminated string. Should be (user) input.
+ * \param[in] s2  NULL-terminated string. Should be known (internal) string.
  *
  * \return M_TRUE if equal, M_FALSE if not equal.
  */
@@ -546,6 +562,13 @@ M_API M_bool M_str_eq(const char *s1, const char *s2);
  *
  * This implementation is constant-time meaning it should not be vulnerable to timing-based attacks.
  * Limited to first max bytes. NULL and "" are considered equal strings.
+ *
+ * s1 will be evaluated to max regardless of the length of s2.
+ * s1 should be the input (user) string and s2 the known (internal)
+ * string. This order causes any timing information from this function
+ * to be the timing of reading s1. The length of s2 cannot be determined
+ * though highly unlikely, to determine the length. While the evaluation
+ * will be constant time it will always be the time to scan the known string.
  *
  * \param[in] s1  NULL-terminated string.
  * \param[in] s2  NULL-terminated string.
@@ -561,8 +584,15 @@ M_API M_bool M_str_caseeq_max(const char *s1, const char *s2, size_t max);
  * This implementation is constant-time meaning it should not be vulnerable to timing-based attacks.
  * NULL and "" are considered equal strings.
  *
- * \param[in] s1 NULL-terminated string.
- * \param[in] s2 NULL-terminated string.
+ * s1 will be evaluated to end regardless of the length of s2.
+ * s1 should be the input (user) string and s2 the known (internal)
+ * string. This order causes any timing information from this function
+ * to be the timing of reading s1. The length of s2 cannot be determined
+ * though highly unlikely, to determine the length. While the evaluation
+ * will be constant time it will always be the time to scan the known string.
+ *
+ * \param[in] s1  NULL-terminated string. Should be (user) input.
+ * \param[in] s2  NULL-terminated string. Should be known (internal) string.
  *
  * \return M_TRUE if equal, M_FALSE if not equal.
  */
@@ -571,8 +601,15 @@ M_API M_bool M_str_caseeq(const char *s1, const char *s2);
 
 /*! Determine if a string ends with a given string.
  *
- * \param[in] s1 NULL-terminated string.
+ * The input is slighly different than M_str_eq(). The input reads:
+ * Check that s1 ends with s2.
+ *
+ * s1 length is never (\see M_str_eq) known because evaluation will always be the length of s2.
+ *
+ * \param[in] s1 NULL-terminated string, or non-terminated string that's at least as long as s2.
+ *               Input string.
  * \param[in] s2 NULL-terminated string.
+ *               Ending string that's being compared to s1.
  *
  * \return M_TRUE if s1 ends with s2, otherwise M_FALSE;
  */
@@ -581,8 +618,15 @@ M_API M_bool M_str_eq_end(const char *s1, const char *s2);
 
 /*! Determine if a string ends with a given string in a case-insensitive manner.
  *
- * \param[in] s1 NULL-terminated string.
+ * The input is slighly different than M_str_caseeq(). The input reads:
+ * Check that s1 ends with s2.
+ *
+ * s1 length is never (\see M_str_caseeq) known because evaluation will always be the length of s2.
+ *
+ * \param[in] s1 NULL-terminated string, or non-terminated string that's at least as long as s2.
+ *               Input string.
  * \param[in] s2 NULL-terminated string.
+ *               Ending string that's being compared to s1.
  *
  * \return M_TRUE if s1 ends with s2, otherwise M_FALSE;
  */
@@ -591,8 +635,15 @@ M_API M_bool M_str_caseeq_end(const char *s1, const char *s2);
 
 /*! Determine if a string starts with a given string.
  *
+ * The input is slighly different than M_str_eq(). The input reads:
+ * Check that s1 starts with s2.
+ *
+ * s1 length is never (\see M_str_eq) known because evaluation will always be the length of s2.
+ *
  * \param[in] s1 NULL-terminated string, or non-terminated string that's at least as long as s2.
+ *               Input string.
  * \param[in] s2 NULL-terminated string.
+ *               Staring string that's being compared to s1.
  *
  * \return       M_TRUE if s1 starts with s2, otherwise M_FALSE.
  */
@@ -601,8 +652,15 @@ M_API M_bool M_str_eq_start(const char *s1, const char *s2);
 
 /*! Determine if a string starts with a given string in a case-insensitive manner.
  *
+ * The input is slighly different than M_str_caseeq(). The input reads:
+ * Check that s1 starts with s2.
+ *
+ * s1 length is never (\see M_str_caseeq) known because evaluation will always be the length of s2.
+ *
  * \param[in] s1 NULL-terminated string, or non-terminated string that's at least as long as s2.
+ *               Input string.
  * \param[in] s2 NULL-terminated string.
+ *               Staring string that's being compared to s1.
  *
  * \return       M_TRUE if s1 starts with s2 (case insensitive), otherwise M_FALSE.
  */


### PR DESCRIPTION
Add a pair of functions to validate that a string contains only ASCII characters in the base64 set, including a terminating '=' for padding