### PR TITLE
fix M_parser_truncate_predicate_max() not truncating correctly

### DIFF
--- a/base/data/m_parser.c
+++ b/base/data/m_parser.c
@@ -806,8 +806,8 @@ size_t M_parser_truncate_until(M_parser_t *parser, const unsigned char *pat, siz
 
 	consumed_len = (size_t)(ptr - parser->data);
 	if (!eat_pat)
-		consumed_len -= len;
-	M_parser_truncate(parser, parser->data_len-consumed_len);
+		consumed_len += len;
+	M_parser_truncate(parser, consumed_len);
 	return consumed_len;
 }
 

--- a/base/data/m_parser.c
+++ b/base/data/m_parser.c
@@ -846,15 +846,15 @@ size_t M_parser_truncate_predicate_max(M_parser_t *parser, M_parser_predicate_fu
 	if (max > parser->data_len)
 		max = parser->data_len;
 
-	for (i=max; i-->0; ) {
-		if (!func(parser->data[i])) {
+	for (i=max; i>0; i--) {
+		if (!func(parser->data[i-1])) {
 			break;
 		}
 	}
 
 	if (i == parser->data_len)
 		return 0;
-	M_parser_truncate(parser, parser->data_len - i);
+	M_parser_truncate(parser, i);
 	return i;
 }
 

--- a/base/data/m_parser.c
+++ b/base/data/m_parser.c
@@ -820,9 +820,9 @@ size_t M_parser_truncate_charset(M_parser_t *parser, const unsigned char *charse
 	if (parser == NULL || charset == NULL || charset_len == 0)
 		return 0;
 
-	for (i=parser->data_len; i-->0; ) {
+	for (i=parser->data_len; i>0; i--) {
 		for (j=0; j<charset_len; j++) {
-			if (parser->data[i] == charset[j])
+			if (parser->data[i-1] == charset[j])
 				break;
 		}
 		if (j == charset_len)
@@ -831,7 +831,7 @@ size_t M_parser_truncate_charset(M_parser_t *parser, const unsigned char *charse
 
 	if (i == parser->data_len)
 		return 0;
-	M_parser_truncate(parser, parser->data_len - i);
+	M_parser_truncate(parser, i);
 	return i;
 }
 


### PR DESCRIPTION
A couple of changes:
1. The parser index is one less than the length for truncation. The loop will now check if the next character needs to be truncated before marking it as needing to be truncated by decrementing the counter (which is essentially the length the parser will be truncated to and not the index). That is, it will look before it leaps.
2. This will truncate to the proper length.

I haven't checked this against other truncate functions yet, wanted to stash this first.