### PR TITLE
Update m_utf8.c

### DIFF
--- a/base/utf8/m_utf8.c
+++ b/base/utf8/m_utf8.c
@@ -77,7 +77,7 @@ static M_bool M_utf8_validate_int(const char *str, const char **endptr, size_t *
 	if (M_str_isempty(str))
 		return 0;
 
-	while (str != NULL && *str != '\0' && res == M_UTF8_ERROR_SUCCESS) {
+	while (res == M_UTF8_ERROR_SUCCESS && *str != '\0') {
 		if (endptr != NULL) {
 			*endptr = str;
 		}

--- a/base/utf8/m_utf8.c
+++ b/base/utf8/m_utf8.c
@@ -77,7 +77,7 @@ static M_bool M_utf8_validate_int(const char *str, const char **endptr, size_t *
 	if (M_str_isempty(str))
 		return 0;
 
-	while (*str != '\0' && res == M_UTF8_ERROR_SUCCESS) {
+	while (str != NULL && *str != '\0' && res == M_UTF8_ERROR_SUCCESS) {
 		if (endptr != NULL) {
 			*endptr = str;
 		}


### PR DESCRIPTION
The while loop starting at line 80 can segfault when `str` is NULL.

In the case that the first byte of `str` is 0xFF, M_utf8_get_cp() will return M_UTF8_ERROR_BAD_START because it cannot find a width. However, before it returns M_UTF8_ERROR_BAD_START, it will set its third arg (const char **next) to NULL. In the while loop starting at line 80, this will set `str` to NULL. When the loop's conditional statement is checked, dereferencing a NULL pointer will cause a segfault.