### PR TITLE
Increase log information on stall timeout

### DIFF
--- a/include/mstdlib/net/m_net_smtp.h
+++ b/include/mstdlib/net/m_net_smtp.h
@@ -357,6 +357,13 @@ M_API M_bool M_net_smtp_load_balance(M_net_smtp_t *sp, M_net_smtp_load_balance_t
  */
 M_API void M_net_smtp_set_num_attempts(M_net_smtp_t *sp, size_t num);
 
+/*! Number of consecutive stall timeouts allowed per endpoint.
+ *
+ * \param[in] sp  SMTP pool.
+ * \param[in] num Number of stall retries per endpoint.  Can be 0 to fail endpoint on first stall.
+ */
+M_API void M_net_smtp_set_stall_retries(M_net_smtp_t *sp, size_t num);
+
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 

--- a/net/smtp/m_flow_tcp.c
+++ b/net/smtp/m_flow_tcp.c
@@ -234,30 +234,30 @@ M_state_machine_t * M_net_smtp_flow_tcp(void)
 
 	m = M_state_machine_create(0, "SMTP-flow-tcp", M_STATE_MACHINE_NONE);
 
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_OPENING_RESPONSE, M_opening_response_post_cb);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_OPENING_RESPONSE, M_opening_response_post_cb, "Opening response");
 
 	sub_m = M_net_smtp_flow_tcp_starttls();
-	M_state_machine_insert_sub_state_machine(m, STATE_STARTTLS, 0, NULL, sub_m,
+	M_state_machine_insert_sub_state_machine(m, STATE_STARTTLS, 0, "Start TLS", sub_m,
 			NULL, M_starttls_post_cb, NULL, NULL);
 	M_state_machine_destroy(sub_m);
 
 	sub_m = M_net_smtp_flow_tcp_ehlo();
-	M_state_machine_insert_sub_state_machine(m, STATE_EHLO, 0, NULL, sub_m,
+	M_state_machine_insert_sub_state_machine(m, STATE_EHLO, 0, "Ehlo", sub_m,
 			NULL, M_ehlo_post_cb, NULL, NULL);
 	M_state_machine_destroy(sub_m);
 
 	sub_m = M_net_smtp_flow_tcp_auth();
-	M_state_machine_insert_sub_state_machine(m, STATE_AUTH, 0, NULL, sub_m,
+	M_state_machine_insert_sub_state_machine(m, STATE_AUTH, 0, "Auth", sub_m,
 			NULL, M_auth_post_cb, NULL, NULL);
 	M_state_machine_destroy(sub_m);
 
 	sub_m = M_net_smtp_flow_tcp_sendmsg();
-	M_state_machine_insert_sub_state_machine(m, STATE_SENDMSG, 0, NULL, sub_m,
+	M_state_machine_insert_sub_state_machine(m, STATE_SENDMSG, 0, "Send message", sub_m,
 			M_sendmsg_pre_cb, M_sendmsg_post_cb, NULL, NULL);
 	M_state_machine_destroy(sub_m);
 
-	M_state_machine_insert_state(m, STATE_WAIT_FOR_NEXT_MSG, 0, NULL, M_state_wait_for_next_msg, NULL, NULL);
-	M_state_machine_insert_state(m, STATE_QUIT, 0, NULL, M_state_quit, NULL, NULL);
-	M_state_machine_insert_state(m, STATE_QUIT_ACK, 0, NULL, M_state_quit_ack, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_WAIT_FOR_NEXT_MSG, 0, "Wait for next message", M_state_wait_for_next_msg, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_QUIT, 0, "Quit", M_state_quit, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_QUIT_ACK, 0, "Quit Acknowledge", M_state_quit_ack, NULL, NULL);
 	return m;
 }

--- a/net/smtp/m_flow_tcp_auth.c
+++ b/net/smtp/m_flow_tcp_auth.c
@@ -522,23 +522,23 @@ M_state_machine_t * M_net_smtp_flow_tcp_auth(void)
 
 	m = M_state_machine_create(0, "SMTP-flow-tcp-auth", M_STATE_MACHINE_NONE);
 
-	M_state_machine_insert_state(m, STATE_AUTH_START, 0, NULL, M_state_auth_start, NULL, NULL);
-	M_state_machine_insert_state(m, STATE_AUTH_PLAIN, 0, NULL, M_state_auth_plain, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_PLAIN_RESPONSE, M_auth_final_response_post_cb);
+	M_state_machine_insert_state(m, STATE_AUTH_START, 0, "Auth start", M_state_auth_start, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_AUTH_PLAIN, 0, "Auth plain", M_state_auth_plain, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_PLAIN_RESPONSE, M_auth_final_response_post_cb, "Auth plain response");
 
-	M_state_machine_insert_state(m, STATE_AUTH_LOGIN, 0, NULL, M_state_auth_login, NULL, NULL);
-	M_state_machine_insert_state(m, STATE_AUTH_LOGIN_USERNAME, 0, NULL, M_state_auth_login_username, NULL, NULL);
-	M_state_machine_insert_state(m, STATE_AUTH_LOGIN_PASSWORD, 0, NULL, M_state_auth_login_password, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_LOGIN_RESPONSE, M_auth_login_response_post_cb);
+	M_state_machine_insert_state(m, STATE_AUTH_LOGIN, 0, "Auth login", M_state_auth_login, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_AUTH_LOGIN_USERNAME, 0, "Auth login username", M_state_auth_login_username, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_AUTH_LOGIN_PASSWORD, 0, "Auth login password", M_state_auth_login_password, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_LOGIN_RESPONSE, M_auth_login_response_post_cb, "Auth login response");
 
-	M_state_machine_insert_state(m, STATE_AUTH_CRAM_MD5, 0, NULL, M_state_auth_cram_md5, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_CRAM_MD5_SECRET_RESPONSE, M_auth_cram_md5_secret_response_post_cb);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_CRAM_MD5_FINAL_RESPONSE, M_auth_final_response_post_cb);
+	M_state_machine_insert_state(m, STATE_AUTH_CRAM_MD5, 0, "Auth cram md5", M_state_auth_cram_md5, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_CRAM_MD5_SECRET_RESPONSE, M_auth_cram_md5_secret_response_post_cb, "Auth cram md5 secret response");
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_CRAM_MD5_FINAL_RESPONSE, M_auth_final_response_post_cb, "Auth cram md5 final response");
 
-	M_state_machine_insert_state(m, STATE_AUTH_DIGEST_MD5, 0, NULL, M_state_auth_digest_md5, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_DIGEST_MD5_NONCE_RESPONSE, M_auth_digest_md5_nonce_response_post_cb);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_DIGEST_MD5_ACK_RESPONSE, M_auth_digest_md5_ack_response_post_cb);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_DIGEST_MD5_FINAL_RESPONSE, M_auth_final_response_post_cb);
+	M_state_machine_insert_state(m, STATE_AUTH_DIGEST_MD5, 0, "Auth digest md5", M_state_auth_digest_md5, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_DIGEST_MD5_NONCE_RESPONSE, M_auth_digest_md5_nonce_response_post_cb, "Auth digest md5 nonce response");
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_DIGEST_MD5_ACK_RESPONSE, M_auth_digest_md5_ack_response_post_cb, "Auth digest md5 ack response");
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_AUTH_DIGEST_MD5_FINAL_RESPONSE, M_auth_final_response_post_cb, "Auth digest md5 final response");
 
 	return m;
 }

--- a/net/smtp/m_flow_tcp_ehlo.c
+++ b/net/smtp/m_flow_tcp_ehlo.c
@@ -128,9 +128,9 @@ M_state_machine_t * M_net_smtp_flow_tcp_ehlo(void)
 	M_state_machine_t *m = NULL;
 
 	m = M_state_machine_create(0, "SMTP-flow-tcp-ehlo", M_STATE_MACHINE_NONE);
-	M_state_machine_insert_state(m, STATE_EHLO, 0, NULL, M_state_ehlo, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_EHLO, 0, "Ehlo", M_state_ehlo, NULL, NULL);
 
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_EHLO_RESPONSE, M_ehlo_response_post_cb);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_EHLO_RESPONSE, M_ehlo_response_post_cb, "Ehlo response");
 
 	return m;
 }

--- a/net/smtp/m_flow_tcp_sendmsg.c
+++ b/net/smtp/m_flow_tcp_sendmsg.c
@@ -248,20 +248,20 @@ M_state_machine_t * M_net_smtp_flow_tcp_sendmsg(void)
 
 	m = M_state_machine_create(0, "SMTP-flow-tcp-sendmsg", M_STATE_MACHINE_NONE);
 
-	M_state_machine_insert_state(m, STATE_MAIL_FROM, 0, NULL, M_state_mail_from, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_MAIL_FROM_RESPONSE, M_mail_from_response_post_cb);
+	M_state_machine_insert_state(m, STATE_MAIL_FROM, 0, "Mail from", M_state_mail_from, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_MAIL_FROM_RESPONSE, M_mail_from_response_post_cb, "Mail from response");
 
-	M_state_machine_insert_state(m, STATE_RCPT_TO, 0, NULL, M_state_rcpt_to, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_RCPT_TO_RESPONSE, M_rcpt_to_response_post_cb);
+	M_state_machine_insert_state(m, STATE_RCPT_TO, 0, "Receipt to", M_state_rcpt_to, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_RCPT_TO_RESPONSE, M_rcpt_to_response_post_cb, "Receipt to response");
 
-	M_state_machine_insert_state(m, STATE_DATA, 0, NULL, M_state_data, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_DATA_RESPONSE, M_data_response_post_cb);
+	M_state_machine_insert_state(m, STATE_DATA, 0, "Data", M_state_data, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_DATA_RESPONSE, M_data_response_post_cb, "Data response");
 
-	M_state_machine_insert_state(m, STATE_DATA_PAYLOAD_AND_STOP, 0, NULL, M_state_data_payload_and_stop, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_DATA_STOP_RESPONSE, M_data_stop_response_post_cb);
+	M_state_machine_insert_state(m, STATE_DATA_PAYLOAD_AND_STOP, 0, "Data payload and stop", M_state_data_payload_and_stop, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_DATA_STOP_RESPONSE, M_data_stop_response_post_cb, "Data payload and stop response");
 
-	M_state_machine_insert_state(m, STATE_RSET, 0, NULL, M_state_rset, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_RSET_RESPONSE, M_rset_response_post_cb);
+	M_state_machine_insert_state(m, STATE_RSET, 0, "Reset", M_state_rset, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_RSET_RESPONSE, M_rset_response_post_cb, "Reset response");
 
 	return m;
 }

--- a/net/smtp/m_flow_tcp_smtp_response.c
+++ b/net/smtp/m_flow_tcp_smtp_response.c
@@ -135,15 +135,15 @@ M_state_machine_t * M_net_smtp_flow_tcp_smtp_response(void)
 {
 	M_state_machine_t *m;
 	m = M_state_machine_create(0, "SMTP-flow-tcp-smtp-response", M_STATE_MACHINE_CONTINUE_LOOP | M_STATE_MACHINE_SELF_CALL);
-	M_state_machine_insert_state(m, STATE_READ_LINE, 0, NULL, M_state_read_line, NULL, NULL);
+	M_state_machine_insert_state(m, STATE_READ_LINE, 0, "Read line", M_state_read_line, NULL, NULL);
 	return m;
 }
 
 void M_net_smtp_flow_tcp_smtp_response_insert_subm(M_state_machine_t *m, M_uint64 id,
-		M_state_machine_post_cb post_cb)
+		M_state_machine_post_cb post_cb, const char *descr)
 {
 	M_state_machine_t *sub_m = M_net_smtp_flow_tcp_smtp_response();
-	M_state_machine_insert_sub_state_machine(m, id, 0, NULL, sub_m,
+	M_state_machine_insert_sub_state_machine(m, id, 0, descr, sub_m,
 			M_net_smtp_flow_tcp_smtp_response_pre_cb_helper, post_cb, NULL, NULL);
 	M_state_machine_destroy(sub_m);
 }

--- a/net/smtp/m_flow_tcp_starttls.c
+++ b/net/smtp/m_flow_tcp_starttls.c
@@ -58,8 +58,8 @@ M_state_machine_t * M_net_smtp_flow_tcp_starttls(void)
 	M_state_machine_t *m = NULL;
 
 	m = M_state_machine_create(0, "SMTP-flow-tcp-sendmsg", M_STATE_MACHINE_NONE);
-	M_state_machine_insert_state(m, STATE_STARTTLS, 0, NULL, M_state_starttls, NULL, NULL);
-	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_STARTTLS_RESPONSE, M_starttls_response_post_cb);
+	M_state_machine_insert_state(m, STATE_STARTTLS, 0, "Start TLS", M_state_starttls, NULL, NULL);
+	M_net_smtp_flow_tcp_smtp_response_insert_subm(m, STATE_STARTTLS_RESPONSE, M_starttls_response_post_cb, "Start TLS response");
 
 	return m;
 }

--- a/net/smtp/m_net_smtp.c
+++ b/net/smtp/m_net_smtp.c
@@ -379,12 +379,13 @@ M_net_smtp_t *M_net_smtp_create(M_event_t *el, const struct M_net_smtp_callbacks
 		sp->cbs.reschedule_cb        = cbs->reschedule_cb        ? cbs->reschedule_cb        : nop_reschedule_cb;
 		sp->cbs.iocreate_cb          = cbs->iocreate_cb          ? cbs->iocreate_cb          : nop_iocreate_cb;
 	}
-	sp->el             = el;
-	sp->thunk          = thunk;
-	sp->status         = M_NET_SMTP_STATUS_NOENDPOINTS;
-	sp->tcp_connect_ms = 5000;
-	sp->tcp_stall_ms   = 5000;
-	sp->tcp_idle_ms    = 1000;
+	sp->el                = el;
+	sp->thunk             = thunk;
+	sp->status            = M_NET_SMTP_STATUS_NOENDPOINTS;
+	sp->tcp_connect_ms    = 5000;
+	sp->tcp_stall_ms      = 5000;
+	sp->tcp_idle_ms       = 1000;
+	sp->max_stall_retries = 4;
 
 	return sp;
 }
@@ -565,6 +566,13 @@ M_bool M_net_smtp_load_balance(M_net_smtp_t *sp, M_net_smtp_load_balance_t mode)
 
 	sp->load_balance_mode = mode;
 	return M_TRUE;
+}
+
+void M_net_smtp_set_stall_retries(M_net_smtp_t *sp, size_t num)
+{
+	if (sp == NULL)
+		return;
+	sp->max_stall_retries = num;
 }
 
 void M_net_smtp_set_num_attempts(M_net_smtp_t *sp, size_t num)

--- a/net/smtp/m_net_smtp_endpoint.h
+++ b/net/smtp/m_net_smtp_endpoint.h
@@ -48,6 +48,7 @@ typedef struct {
 			M_bool         connect_tls;
 			char          *username;
 			char          *password;
+			size_t         stall_retries;
 		} tcp;
 		struct {
 			char          *command;

--- a/net/smtp/m_net_smtp_flow.h
+++ b/net/smtp/m_net_smtp_flow.h
@@ -27,7 +27,7 @@
 M_bool M_net_smtp_flow_tcp_check_smtp_response_code(M_net_smtp_session_t *session, M_uint64 expected_code);
 
 void                       M_net_smtp_flow_tcp_smtp_response_insert_subm(
-		M_state_machine_t *m, M_uint64 id, M_state_machine_post_cb post_cb);
+		M_state_machine_t *m, M_uint64 id, M_state_machine_post_cb post_cb, const char *descr);
 M_state_machine_t         *M_net_smtp_flow_process(void);
 M_state_machine_cleanup_t *M_net_smtp_flow_tcp_smtp_response_cleanup(void);
 M_state_machine_t         *M_net_smtp_flow_tcp_smtp_response(void);

--- a/net/smtp/m_net_smtp_int.h
+++ b/net/smtp/m_net_smtp_int.h
@@ -57,6 +57,7 @@ struct M_net_smtp {
 	size_t                             round_robin_idx;
 	M_event_timer_t                   *restart_processing_timer;
 	M_net_smtp_queue_t                *queue;
+	size_t                             max_stall_retries;
 };
 
 typedef struct {

--- a/net/smtp/m_net_smtp_session.c
+++ b/net/smtp/m_net_smtp_session.c
@@ -143,13 +143,16 @@ static session_status_t session_tcp_advance(M_event_t *el, M_event_type_t etype,
 			}
 			do {
 				if (etype == M_EVENT_TYPE_OTHER) {
+					char *descr;
 					if (session->connection_mask == M_NET_SMTP_CONNECTION_MASK_NONE) {
 						session->tcp.net_error = M_NET_ERROR_TIMEOUT;
 						M_snprintf(session->errmsg, sizeof(session->errmsg), "Connection timeout");
 						break;
 					}
 					session->tcp.net_error = M_NET_ERROR_TIMEOUT_STALL;
-					M_snprintf(session->errmsg, sizeof(session->errmsg), "Stall timeout.  Message size: %zu, Remaining out buffer size: %zu, Current state is \"%s\".", M_str_len(session->msg), M_buf_len(session->out_buf), M_state_machine_descr_full(session->state_machine, M_FALSE));
+					descr = M_state_machine_descr_full(session->state_machine, M_FALSE);
+					M_snprintf(session->errmsg, sizeof(session->errmsg), "Stall timeout.  Message size: %zu, Remaining out buffer size: %zu, Current state: %s.", M_str_len(session->msg), M_buf_len(session->out_buf), descr);
+					M_free(descr);
 					if (session->ep->tcp.stall_retries < session->sp->max_stall_retries) {
 						goto destroy;
 					}

--- a/net/smtp/m_net_smtp_session.c
+++ b/net/smtp/m_net_smtp_session.c
@@ -149,7 +149,7 @@ static session_status_t session_tcp_advance(M_event_t *el, M_event_type_t etype,
 						break;
 					}
 					session->tcp.net_error = M_NET_ERROR_TIMEOUT_STALL;
-					M_snprintf(session->errmsg, sizeof(session->errmsg), "Stall timeout (message is %zu bytes)", M_str_len(session->msg));
+					M_snprintf(session->errmsg, sizeof(session->errmsg), "Stall timeout.  Message size: %zu, Remaining out buffer size: %zu, Current state is \"%s\".", M_str_len(session->msg), M_buf_len(session->out_buf), M_state_machine_descr_full(session->state_machine, M_FALSE));
 					break;
 				}
 				M_io_get_error_string(io, session->errmsg, sizeof(session->errmsg));

--- a/net/smtp/m_net_smtp_session.h
+++ b/net/smtp/m_net_smtp_session.h
@@ -63,7 +63,7 @@ typedef struct {
 	M_buf_t                     *out_buf;
 	M_parser_t                  *in_parser;
 	M_event_timer_t             *event_timer;
-	char                         errmsg[128];
+	char                         errmsg[256];
 	union {
 		struct {
 			M_bool                  is_starttls_capable;

--- a/test/net/check_smtp.c
+++ b/test/net/check_smtp.c
@@ -2634,6 +2634,7 @@ START_TEST(endpoint_timeout)
 	args.el = el;
 	args.test_id = ENDPOINT_TIMEOUT;
 
+	M_net_smtp_setup_tcp_timeouts(sp, 1000, 1000, 1000);
 	M_net_smtp_setup_tcp(sp, dns, NULL);
 	ck_assert_msg(M_net_smtp_add_endpoint_tcp(sp, "localhost", testport, M_FALSE, "user", "pass", 1) == M_TRUE,
 			"should succeed adding tcp after setting dns");


### PR DESCRIPTION
Add description to state machines.  On Stall log current state, message size, and remaining bytes on out buffer.

modified:   net/smtp/m_flow_tcp.c
modified:   net/smtp/m_flow_tcp_auth.c
modified:   net/smtp/m_flow_tcp_ehlo.c
modified:   net/smtp/m_flow_tcp_sendmsg.c
modified:   net/smtp/m_flow_tcp_smtp_response.c
modified:   net/smtp/m_flow_tcp_starttls.c
modified:   net/smtp/m_net_smtp_flow.h
modified:   net/smtp/m_net_smtp_session.c
modified:   net/smtp/m_net_smtp_session.h